### PR TITLE
[WIP] hydroplane: add a runtime backend for Kubernetes IN Docker (kind)

### DIFF
--- a/examples/kind-config.yaml
+++ b/examples/kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 31000
+    hostPort: 8080
+    listenAddress: "0.0.0.0"

--- a/examples/kind-runtime.yml
+++ b/examples/kind-runtime.yml
@@ -1,0 +1,7 @@
+---
+secret_store:
+    secret_store_type: none
+
+runtime:
+    runtime_type: kind
+    node_port: 31000

--- a/hydroplane/config.py
+++ b/hydroplane/config.py
@@ -7,6 +7,7 @@ from .secret_stores.none import Settings as NoOpSecretStoreSettings
 from .runtimes.docker import Settings as DockerRuntimeSettings
 from .runtimes.eks import Settings as EKSRuntimeSettings
 from .runtimes.gke import Settings as GKERuntimeSettings
+from .runtimes.kind import Settings as KindRuntimeSettings
 from .utils.process_culler import Settings as ProcessCullerSettings
 
 
@@ -14,7 +15,7 @@ class Settings(BaseModel):
     secret_store: Union[LocalSecretStoreSettings, NoOpSecretStoreSettings] = \
         Field(..., discriminator='secret_store_type')
 
-    runtime: Union[DockerRuntimeSettings, EKSRuntimeSettings, GKERuntimeSettings] = \
+    runtime: Union[DockerRuntimeSettings, EKSRuntimeSettings, GKERuntimeSettings, KindRuntimeSettings] = \
         Field(..., discriminator='runtime_type')
 
     process_culling: Optional[ProcessCullerSettings]

--- a/hydroplane/runtimes/factory.py
+++ b/hydroplane/runtimes/factory.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from .docker import DockerRuntime, RUNTIME_TYPE as DOCKER_RUNTIME_TYPE
 from .eks import EKSRuntime, RUNTIME_TYPE as EKS_RUNTIME_TYPE
 from .gke import GKERuntime, RUNTIME_TYPE as GKE_RUNTIME_TYPE
+from .kind import KindRuntime, RUNTIME_TYPE as KIND_RUNTIME_TYPE
 from .runtime import Runtime
 from ..secret_stores.secret_store import SecretStore
 
@@ -18,3 +19,5 @@ def get_runtime(secret_store: SecretStore, settings: "Settings") -> Runtime:
         return EKSRuntime(settings.runtime, secret_store)
     elif settings.runtime.runtime_type == GKE_RUNTIME_TYPE:
         return GKERuntime(settings.runtime, secret_store)
+    elif settings.runtime.runtime_type == KIND_RUNTIME_TYPE:
+        return KindRuntime(settings.runtime, secret_store)  

--- a/hydroplane/runtimes/kind.py
+++ b/hydroplane/runtimes/kind.py
@@ -1,0 +1,98 @@
+import logging
+from pathlib import Path
+from typing import List, Literal, Optional
+
+from kubernetes import config as k8sconfig
+
+from kubernetes.client import ApiClient
+from pydantic import BaseModel, Field
+
+
+from ..models.process_info import ProcessInfo
+from ..utils.k8s import k8s_start_process, k8s_list_processes, k8s_stop_group, k8s_stop_process
+from ..models.process_spec import ProcessSpec
+from .runtime import Runtime
+from ..secret_stores.secret_store import SecretStore
+
+RUNTIME_TYPE = 'kind'
+
+
+class Settings(BaseModel):
+    runtime_type: Literal[RUNTIME_TYPE] = RUNTIME_TYPE  # type: ignore
+
+    context: str = Field(None, description='context to use')
+    namespace: str = Field('default', description='the Kubernetes namespace that Hydroplane will create pods and services within')
+    # This is something that Kubernetes auto-assigns. However, in order to expose
+    # a NodePort service using kind, we need to pre-map ports in the kind configuration
+    # and make sure that nodePort assigned in the serviceSpec is equal to the one
+    # used in the port mapping. 
+    #
+    # A default of 30007 is set because Kubernetes by default assigns a port from
+    # the range 30000-32767. It would be nice to validate this range as a pre-check, but
+    # starting Kubernetes 1.28, it is possible to assign port ranges to NodePort services
+    # (enabled by default). Because of this validation becomes slightly more involved. It
+    # might be worth looking into in the future.
+    node_port: int = Field(30007, description='the port that will be used to expose the service')
+
+logger = logging.getLogger('kind_runtime')
+
+
+class KindRuntime(Runtime):
+    """
+    A runtime for Kubernetes In Docker (https://kind.sigs.k8s.io/)
+    """
+    def __init__(self, settings: Settings, secret_store: SecretStore):
+        self.settings = settings
+        self.secret_store = secret_store
+
+        self._k8s_client: Optional[ApiClient] = None
+        self._node_port = self.settings.node_port
+        
+        k8sconfig.load_kube_config()
+
+    @property
+    def k8s_client(self) -> ApiClient:
+        if self._k8s_client is None:
+            self._k8s_client = self._new_k8s_client()
+        return self._k8s_client
+
+    def _new_k8s_client(self) -> ApiClient:
+        # ApiClient by default loads the default Configuration class
+        # which is set by the load_kube_config() method during init.
+        return ApiClient()
+
+    def start_process(self, process_spec: ProcessSpec):
+        k8s_start_process(
+            self.k8s_client,
+            namespace=self.settings.namespace,
+            process_spec=process_spec,
+            node_port=self._node_port
+        )
+
+
+    def stop_process(self, process_name: str):
+        k8s_stop_process(
+            self.k8s_client,
+            namespace=self.settings.namespace,
+            process_name=process_name
+        )
+
+
+    def stop_group(self, group: str):
+        k8s_stop_group(
+            self.k8s_client,
+            namespace=self.settings.namespace,
+            group=group
+        )
+
+
+    def list_processes(self, group: Optional[str]) -> List[ProcessInfo]:
+        return k8s_list_processes(
+            self.k8s_client,
+            namespace=self.settings.namespace,
+            group=group,
+            node_port=self._node_port
+        )
+
+    def refresh_api_clients(self):
+        pass


### PR DESCRIPTION
This PR adds a runtime backend for kind, which is a fully
conformant Kubernetes distribution created and maintained by the
Kubernetes community: https://kind.sigs.k8s.io/

Having a kind backend helps users test Kubernetes deployments via
Hydro, but locally and in a lightweight manner. kind is also used
in running the CI for the Kubernetes project, which makes it suitable
for writing and running more sophisticated e2e tests for Kubernetes
on hydroplane.

This commit introduced a configuration file for the kind runtime and
adapts the Kubernetes util functions to work with it while not breaking
existing compatibility.

There are some pitfalls to how things are done in the present state
of the commit, primarily how node port mappings are handled. But
considering this backend would be used primarily for testing purposes,
having a less than ideal configuration mechanism might be within the
appetite of complexity we are willing to take on.

TODO:
Add docs
